### PR TITLE
Protected routes

### DIFF
--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,2 +1,3 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
+import { getToken } from 'next-auth/jwt'

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -10,5 +10,8 @@ export const config = {
 }
 
 export async function middleware(request:NextRequest) {
-  const protectedRoutes: string[] = ['/map', "/members", "/reports", "/wealth-analysis"]
+  const protectedRoutes: string[] = ['/map', "/members", "/reports", "/wealth-analysis"];
+
+   const authRoutes: string[] = ['/login', '/register']
+  const { pathname } = request.nextUrl
 }

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -18,4 +18,7 @@ export async function middleware(request:NextRequest) {
    const isProtectedRoute = protectedRoutes.some((route) =>
     pathname.startsWith(route)
   )
+
+   const isAuthRoute = authRoutes.includes(pathname)
+
 }

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -20,5 +20,9 @@ export async function middleware(request:NextRequest) {
   )
 
    const isAuthRoute = authRoutes.includes(pathname)
-
+ 
+   const token = await getToken({
+    req: request,
+    secret: process.env.NEXTAUTH_SECRET
+  })
 }

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,2 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -30,6 +30,10 @@ export async function middleware(request:NextRequest) {
     const signInUrl = new URL('/login', request.url)
     signInUrl.searchParams.set('callbackUrl', request.nextUrl.href)
     return NextResponse.redirect(signInUrl)
+    }
+
+      if (isAuthRoute && token) {
+    return NextResponse.redirect(new URL('/map', request.url))
   }
 
 }

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -8,3 +8,7 @@ export const config = {
     '/((?!api|_next/static|_next/image|favicon.ico|auth).*)',
   ],
 }
+
+export async function middleware(request:NextRequest) {
+  const protectedRoutes: string[] = ['/map', "/members", "/reports", "/wealth-analysis"]
+}

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,3 +1,10 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { getToken } from 'next-auth/jwt'
+
+
+export const config = {
+  matcher: [
+    '/((?!api|_next/static|_next/image|favicon.ico|auth).*)',
+  ],
+}

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -25,4 +25,11 @@ export async function middleware(request:NextRequest) {
     req: request,
     secret: process.env.NEXTAUTH_SECRET
   })
+
+    if (isProtectedRoute && !token) {
+    const signInUrl = new URL('/login', request.url)
+    signInUrl.searchParams.set('callbackUrl', request.nextUrl.href)
+    return NextResponse.redirect(signInUrl)
+  }
+
 }

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -33,7 +33,10 @@ export async function middleware(request:NextRequest) {
     }
 
       if (isAuthRoute && token) {
-    return NextResponse.redirect(new URL('/map', request.url))
-  }
+        return NextResponse.redirect(new URL('/map', request.url))
+     }
+      
+     
+     return NextResponse.next()
 
 }

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -13,5 +13,9 @@ export async function middleware(request:NextRequest) {
   const protectedRoutes: string[] = ['/map', "/members", "/reports", "/wealth-analysis"];
 
    const authRoutes: string[] = ['/login', '/register']
-  const { pathname } = request.nextUrl
+   const { pathname } = request.nextUrl
+
+   const isProtectedRoute = protectedRoutes.some((route) =>
+    pathname.startsWith(route)
+  )
 }


### PR DESCRIPTION

* Added `middleware.ts` using **Next.js Middleware** and **`next-auth`'s `getToken`**.
* Protects the following routes:

  * `/map`
  * `/members`
  * `/reports`
  * `/wealth-analysis`
* If the user is **not authenticated**, they are redirected to `/login` with a `callbackUrl`.
* If the user **is authenticated** and visits `/login` or `/register`, they are redirected to `/map`.
* Configured a `matcher` to exclude public routes like:

  * `/api`
  * `/_next/static`
  * `/_next/image`
  * `/favicon.ico`
  * `/auth`
* Uses `NextRequest` and `NextResponse` from `next/server`.

